### PR TITLE
build(docker): bump up base alpine version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1.3
-FROM            alpine:3.17 as uploader
+FROM            alpine:3.20 as uploader
 USER            root
 WORKDIR         /tmp
 RUN             apk -U add gnupg curl
@@ -50,7 +50,7 @@ RUN yarn install
 RUN yarn build && rm -f build/mockServiceWorker.js
 
 
-FROM alpine:3.17
+FROM alpine:3.20
 ARG REACT_APP_CODECOV_VERSION
 ARG ENVIRONMENT
 ARG COMMIT_SHA


### PR DESCRIPTION
# Description

This PR attempts to address https://github.com/codecov/feedback/issues/705.

In the current docker there's usage of 3.17 alpine which is EOL, trying to update it to the mainline supported version. Does not introduce any other runtime changes.

Peeking history, there was a recent change in https://github.com/codecov/feedback/issues/705 which partially updates the version but the rest of usages are still there. PR aligns the version usage in other places.

# Code Example

# Notable Changes

# Screenshots

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
